### PR TITLE
Fix: 필터링 조건 변경 및 네이버 쇼핑 요청 sort, displace 수정

### DIFF
--- a/src/main/java/com/kyonggi/backend/external/naverShopping/ShoppingRequest.java
+++ b/src/main/java/com/kyonggi/backend/external/naverShopping/ShoppingRequest.java
@@ -11,8 +11,9 @@ import org.springframework.util.MultiValueMap;
 @NoArgsConstructor
 public class ShoppingRequest {
     private String query = "";
-    private Integer display = 10;
-    private String sort = "asc"; // 최저가 정렬
+    private Integer display = 100;
+    private String sort = "sim"; // 정확도 기준
+    //private String sort = "asc"; // 최저가 정렬
 
 
     public MultiValueMap<String, String> map() {


### PR DESCRIPTION
## 연관된 이슈

> #11 

## 작업 내용

> 기존에 적은 양을 검색했는데 최대인 100개로 display를 설정하고 기존 sort 기준인 asc을  sim 으로 정확도 기준 변경했다.
그리고 필터링 후 가격으로 정렬
> 필터링에서 brand명과 maker이 null이 아닌 경우 같은 brand 내에서 검색 결과가 나오도록 수정

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/da3b6666-c2f2-4fbf-a999-5d4ad0823482)

![image](https://github.com/user-attachments/assets/8328aa40-ccab-4fdc-aa2b-1bc74a41fd46)

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 
