### PR TITLE
Feat: 기록 장바구니 삭제 기능 추가 및 api 경로 수정

### DIFF
--- a/src/main/java/com/kyonggi/backend/model/cart/controller/CartControllerV2.java
+++ b/src/main/java/com/kyonggi/backend/model/cart/controller/CartControllerV2.java
@@ -31,13 +31,13 @@ public class CartControllerV2 {
     private final CartRepository cartRepository;
 
     @PostMapping("/add")
-    public ResponseEntity<OnlineItemDto> add(@RequestHeader(value = "Authorization", required = true) String token, @RequestBody OnlineItemDto onlineItemDto) {
+    public ResponseEntity<OnlineItemDto> add(@RequestHeader(value = "Authorization", required = false) String token, @RequestBody OnlineItemDto onlineItemDto) {
         Long memberId = extractMemberIdFromToken(token);
         return ResponseEntity.ok(cartService.addItemToCart(onlineItemDto, memberId));
     }
 
-    @DeleteMapping("/remove")
-    public ResponseEntity<Void> removeItem(@RequestHeader(value = "Authorization", required = true) String token,
+    @PostMapping("/removeItem")
+    public ResponseEntity<Void> removeItem(@RequestHeader(value = "Authorization", required = false) String token,
                                            @RequestBody List<CartItemDto> selectedItems) {
 
         Long memberId = extractMemberIdFromToken(token);
@@ -45,9 +45,8 @@ public class CartControllerV2 {
         return ResponseEntity.ok().build();
     }
 
-
     @PostMapping("/show")
-    public ResponseEntity<List<CartItemDto>> showCart(@RequestHeader(value = "Authorization", required = true) String token) {
+    public ResponseEntity<List<CartItemDto>> showCart(@RequestHeader(value = "Authorization", required = false) String token) {
         Long memberId = extractMemberIdFromToken(token);
         Member member = memberRepository.findById(memberId).get(); // 예외 처리 추가
         List<OnlineItem> items= cartRepository.findActiveCartByMember(member);
@@ -73,7 +72,7 @@ public class CartControllerV2 {
     // 장바구니 비활성화 (구매 완료 처리)
     @PostMapping("/complete")
     public ResponseEntity<Void> completeCart(
-            @RequestHeader(value = "Authorization", required = true) String token,
+            @RequestHeader(value = "Authorization", required = false) String token,
             @RequestBody List<CartItemDto> selectedItems) {
 
         Long memberId = extractMemberIdFromToken(token);
@@ -83,7 +82,7 @@ public class CartControllerV2 {
 
     @PostMapping("/history")
     public ResponseEntity<List<CartSummaryDto>> showCompletedCarts(
-            @RequestHeader(value = "Authorization", required = true) String token) {
+            @RequestHeader(value = "Authorization", required = false) String token) {
 
         Long memberId = extractMemberIdFromToken(token);
         Member member = memberRepository.findById(memberId).orElseThrow();
@@ -98,6 +97,17 @@ public class CartControllerV2 {
 
         return ResponseEntity.ok(result);
     }
+
+
+    @PostMapping("/removeHistory")
+    public ResponseEntity<Void> removeHistory(@RequestHeader(value = "Authorization", required = false) String token,
+                                              @RequestBody List<CartSummaryDto> selectedCarts) {
+
+        Long memberId = extractMemberIdFromToken(token);
+        cartService.removeCartFromHistory(selectedCarts, memberId);
+        return ResponseEntity.ok().build();
+    }
+
 
     @GetMapping("/history/{cartId}")
     public ResponseEntity<List<CartItemDto>> showCartItemsById(@PathVariable(name="cartId") Long cartId) {
@@ -130,28 +140,28 @@ public class CartControllerV2 {
 
 
     // 토큰에서 memberId 추출
-    private Long extractMemberIdFromToken(String token) {
-        if (token.startsWith("Bearer ")) {
-            token = token.substring(7).trim();
-        }
-        try {
-            String username = jwtUtil.getUsername(token);
-            Long memberId = memberRepository.findByUsername(username).get().getId();
-            return memberId;
-
-        } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
-        }
-    }
-
-    //// test 임의로 "qwer1234"로 memberId를 가져옴 >>
 //    private Long extractMemberIdFromToken(String token) {
-//
+//        if (token.startsWith("Bearer ")) {
+//            token = token.substring(7).trim();
+//        }
 //        try {
-//            return memberRepository.findByUsername("qwer1234").get().getId();
+//            String username = jwtUtil.getUsername(token);
+//            Long memberId = memberRepository.findByUsername(username).get().getId();
+//            return memberId;
+//
 //        } catch (Exception e) {
-//            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+//            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
 //        }
 //    }
+
+    //// test 임의로 "qwer1234"로 memberId를 가져옴 >>
+    private Long extractMemberIdFromToken(String token) {
+
+        try {
+            return memberRepository.findByUsername("testuser").get().getId();
+        } catch (Exception e) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+        }
+    }
 
 }

--- a/src/main/java/com/kyonggi/backend/model/cart/controller/CartControllerV2.java
+++ b/src/main/java/com/kyonggi/backend/model/cart/controller/CartControllerV2.java
@@ -31,13 +31,13 @@ public class CartControllerV2 {
     private final CartRepository cartRepository;
 
     @PostMapping("/add")
-    public ResponseEntity<OnlineItemDto> add(@RequestHeader(value = "Authorization", required = false) String token, @RequestBody OnlineItemDto onlineItemDto) {
+    public ResponseEntity<OnlineItemDto> add(@RequestHeader(value = "Authorization", required = true) String token, @RequestBody OnlineItemDto onlineItemDto) {
         Long memberId = extractMemberIdFromToken(token);
         return ResponseEntity.ok(cartService.addItemToCart(onlineItemDto, memberId));
     }
 
     @PostMapping("/removeItem")
-    public ResponseEntity<Void> removeItem(@RequestHeader(value = "Authorization", required = false) String token,
+    public ResponseEntity<Void> removeItem(@RequestHeader(value = "Authorization", required = true) String token,
                                            @RequestBody List<CartItemDto> selectedItems) {
 
         Long memberId = extractMemberIdFromToken(token);
@@ -46,7 +46,7 @@ public class CartControllerV2 {
     }
 
     @PostMapping("/show")
-    public ResponseEntity<List<CartItemDto>> showCart(@RequestHeader(value = "Authorization", required = false) String token) {
+    public ResponseEntity<List<CartItemDto>> showCart(@RequestHeader(value = "Authorization", required = true) String token) {
         Long memberId = extractMemberIdFromToken(token);
         Member member = memberRepository.findById(memberId).get(); // 예외 처리 추가
         List<OnlineItem> items= cartRepository.findActiveCartByMember(member);
@@ -72,7 +72,7 @@ public class CartControllerV2 {
     // 장바구니 비활성화 (구매 완료 처리)
     @PostMapping("/complete")
     public ResponseEntity<Void> completeCart(
-            @RequestHeader(value = "Authorization", required = false) String token,
+            @RequestHeader(value = "Authorization", required = true) String token,
             @RequestBody List<CartItemDto> selectedItems) {
 
         Long memberId = extractMemberIdFromToken(token);
@@ -82,7 +82,7 @@ public class CartControllerV2 {
 
     @PostMapping("/history")
     public ResponseEntity<List<CartSummaryDto>> showCompletedCarts(
-            @RequestHeader(value = "Authorization", required = false) String token) {
+            @RequestHeader(value = "Authorization", required = true) String token) {
 
         Long memberId = extractMemberIdFromToken(token);
         Member member = memberRepository.findById(memberId).orElseThrow();
@@ -100,7 +100,7 @@ public class CartControllerV2 {
 
 
     @PostMapping("/removeHistory")
-    public ResponseEntity<Void> removeHistory(@RequestHeader(value = "Authorization", required = false) String token,
+    public ResponseEntity<Void> removeHistory(@RequestHeader(value = "Authorization", required = true) String token,
                                               @RequestBody List<CartSummaryDto> selectedCarts) {
 
         Long memberId = extractMemberIdFromToken(token);
@@ -140,28 +140,28 @@ public class CartControllerV2 {
 
 
     // 토큰에서 memberId 추출
-//    private Long extractMemberIdFromToken(String token) {
-//        if (token.startsWith("Bearer ")) {
-//            token = token.substring(7).trim();
-//        }
-//        try {
-//            String username = jwtUtil.getUsername(token);
-//            Long memberId = memberRepository.findByUsername(username).get().getId();
-//            return memberId;
-//
-//        } catch (Exception e) {
-//            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
-//        }
-//    }
-
-    //// test 임의로 "qwer1234"로 memberId를 가져옴 >>
     private Long extractMemberIdFromToken(String token) {
-
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7).trim();
+        }
         try {
-            return memberRepository.findByUsername("testuser").get().getId();
+            String username = jwtUtil.getUsername(token);
+            Long memberId = memberRepository.findByUsername(username).get().getId();
+            return memberId;
+
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid token");
         }
     }
+
+    //// test 임의로 "qwer1234"로 memberId를 가져옴 >>
+//    private Long extractMemberIdFromToken(String token) {
+//
+//        try {
+//            return memberRepository.findByUsername("testuser").get().getId();
+//        } catch (Exception e) {
+//            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid token");
+//        }
+//    }
 
 }

--- a/src/main/java/com/kyonggi/backend/model/cart/dto/CartSummaryDto.java
+++ b/src/main/java/com/kyonggi/backend/model/cart/dto/CartSummaryDto.java
@@ -1,10 +1,14 @@
 package com.kyonggi.backend.model.cart.dto;
 
-import lombok.Data;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
 public class CartSummaryDto {
     private Long cartId;
     private String name;

--- a/src/main/java/com/kyonggi/backend/model/cart/service/CartServiceV2.java
+++ b/src/main/java/com/kyonggi/backend/model/cart/service/CartServiceV2.java
@@ -1,6 +1,7 @@
 package com.kyonggi.backend.model.cart.service;
 
 import com.kyonggi.backend.model.cart.dto.CartItemDto;
+import com.kyonggi.backend.model.cart.dto.CartSummaryDto;
 import com.kyonggi.backend.model.cart.entity.Cart;
 import com.kyonggi.backend.model.item.OnlineItem;
 import com.kyonggi.backend.model.item.dto.OnlineItemDto;
@@ -71,6 +72,26 @@ public class CartServiceV2 {
 
         memberRepository.save(member);
     }
+
+    public void removeCartFromHistory(List<CartSummaryDto> selectedCarts, Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow();
+
+        List<Long> cartIdsToDelete = selectedCarts.stream()
+                .map(CartSummaryDto::getCartId)
+                .toList();
+
+        System.out.println("🧾 삭제할 기록용 장바구니 ID: " + cartIdsToDelete);       //테스트용 로그
+
+        boolean removed = member.getCartList().removeIf(cart ->
+                !cart.isActive() && cartIdsToDelete.contains(cart.getId())
+        );
+
+        System.out.println("✅ 삭제 성공 여부: " + removed);
+
+        memberRepository.save(member);
+    }
+
+
 
 
 //    public void completeCart(List<CartItemDto> selectedItems, Long memberId) {

--- a/src/main/java/com/kyonggi/backend/model/member/entity/Member.java
+++ b/src/main/java/com/kyonggi/backend/model/member/entity/Member.java
@@ -24,7 +24,7 @@ public class Member {
     private String role;
     private String name;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Cart> cartList = new ArrayList<>();
 
 //    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호

## 작업 내용

기존 cart/remove에서 cart/removeItem, cart/removeIHistory로 세분화
기록 장바구니 삭제 기능(removeIHistory) 구현 -> 프런트에는 아직 연동 안 시킴

## 스크린샷 (선택)
![스크린샷 2025-04-14 022304](https://github.com/user-attachments/assets/5cccc35f-47d6-4f41-8777-0159eeb2d73b)

![스크린샷 2025-04-14 022318](https://github.com/user-attachments/assets/f403781b-7fc0-4c86-8588-5881a91ab33f)

![스크린샷 2025-04-14 022331](https://github.com/user-attachments/assets/f309d461-b7af-4313-98d2-4055e1ab84cf)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
