### PR TITLE
[Feat] 장바구니 기록 창 관련 필드 추가

### DIFF
--- a/src/main/java/com/kyonggi/backend/model/cart/controller/CartControllerV2.java
+++ b/src/main/java/com/kyonggi/backend/model/cart/controller/CartControllerV2.java
@@ -96,8 +96,32 @@ public class CartControllerV2 {
                 .toList();
 
         List<CartSummaryDto> result = carts.stream()
-                .map(cart -> new CartSummaryDto(cart.getId(), cart.getName(),cart.getCreatedAt()))
+                .map(cart -> {
+                    List<Item> items = cart.getItemList();
+
+                    int totalQuantity = items.stream().mapToInt(Item::getQuantity).sum();
+
+                    int totalPrice = items.stream()
+                            .mapToInt(item -> item.getPrice() * item.getQuantity())
+                            .sum();
+
+                    String thumbnailUrl = items.stream()
+                            .filter(item -> item instanceof OnlineItem)
+                            .map(item -> ((OnlineItem) item).getImage())
+                            .findFirst()
+                            .orElse("https://via.placeholder.com/60"); // 기본 이미지
+
+                    return new CartSummaryDto(
+                            cart.getId(),
+                            cart.getName(),
+                            cart.getCreatedAt(),
+                            thumbnailUrl,
+                            totalQuantity,
+                            totalPrice
+                    );
+                })
                 .toList();
+
 
         return ResponseEntity.ok(result);
     }

--- a/src/main/java/com/kyonggi/backend/model/cart/dto/CartSummaryDto.java
+++ b/src/main/java/com/kyonggi/backend/model/cart/dto/CartSummaryDto.java
@@ -12,11 +12,19 @@ public class CartSummaryDto {
     private Long cartId;
     private String name;
     private LocalDateTime createdAt;
+    private String thumbnailUrl;
+    private int totalQuantity;
+    private int totalPrice;
 
-    public CartSummaryDto(Long cartId, String name, LocalDateTime createdAt) {
+    public CartSummaryDto(Long cartId, String name, LocalDateTime createdAt,
+                          String thumbnailUrl, int totalQuantity, int totalPrice) {
         this.cartId = cartId;
         this.name = name;
         this.createdAt = createdAt;
+        this.thumbnailUrl = thumbnailUrl;
+        this.totalQuantity = totalQuantity;
+        this.totalPrice = totalPrice;
     }
+
 }
 


### PR DESCRIPTION
## 연관된 이슈

> ex) #이슈번호, #이슈번호

## 작업 내용

> 장바구니 기록에서 가져올 썸네일, 상품 수량, 총 금액 필드 추가
> Controller의 history api 부분 변경 적용

## 스크린샷 (선택)
![스크린샷 2025-04-29 223351](https://github.com/user-attachments/assets/dd63ba48-0e76-4c05-81b8-afae8a189a70)

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?

## 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요
